### PR TITLE
Deprecated macs2 -> macs3

### DIFF
--- a/environments/macs.yaml
+++ b/environments/macs.yaml
@@ -6,4 +6,4 @@ channels:
   
 dependencies:
   - python
-  - macs2
+  - macs3

--- a/snakefiles/preprocessing.snake
+++ b/snakefiles/preprocessing.snake
@@ -109,7 +109,7 @@ rule macs:
 	log: 
 		os.path.join(OUTPUTDIR, "logs", "{condition}_{sample_id}_peak_calling.log")
 	message: 
-		"Running macs2 with .bam-file: {input}"
+		"Running macs3 with .bam-file: {input}"
 	conda: 
 		os.path.join(environments_dir, "macs.yaml")
 	params:
@@ -118,7 +118,7 @@ rule macs:
 		"--gsize " + str(gsizes[config["run_info"]["organism"]]),
 		config.get("macs", "--nomodel --shift -100 --extsize 200 --broad"),
 	shell:
-		"macs2 callpeak -t {input} {params} &> {log}; "
+		"macs3 callpeak -t {input} {params} &> {log}; "
 		"cp {output.macs} {output.raw}; " 
 
 


### PR DESCRIPTION
Use macs3 to avoid macs2 error. Fixes #17 