### PR TITLE
New version

### DIFF
--- a/environments/tobias.yaml
+++ b/environments/tobias.yaml
@@ -9,8 +9,8 @@ dependencies:
   - gimmemotifs
   - sklearn-contrib-lightning
   - matplotlib<3.8  # fix for 'matplotlib.cbook' has no attribute 'mplDeprecation'
+  - tobias>=0.17
   - pip
   - pip:
-    - tobias>=0.17
     - adjustText
     - pypdf2<3.0  # PdfFileMerger is deprecated in 3.0


### PR DESCRIPTION
Fixes the numpy error by installing the newest TOBIAS version using bioconda

Error:
```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.3.5 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "...", line 3, in <module>
    from tobias.TOBIAS import main
  File ".../python3.11/site-packages/tobias/TOBIAS.py", line 31, in <module>
    from tobias.parsers import *
  File ".../python3.11/site-packages/tobias/parsers.py", line 13, in <module>
    from tobias.utils.utilities import format_help_description, restricted_float, add_underscore_options
  File ".../python3.11/site-packages/tobias/utils/utilities.py", line 26, in <module>
    import pyBigWig
AttributeError: _ARRAY_API not found
Traceback (most recent call last):
  File "...", line 3, in <module>
    from tobias.TOBIAS import main
  File ".../python3.11/site-packages/tobias/TOBIAS.py", line 31, in <module>
    from tobias.parsers import *
  File ".../python3.11/site-packages/tobias/parsers.py", line 13, in <module>
    from tobias.utils.utilities import format_help_description, restricted_float, add_underscore_options
  File ".../python3.11/site-packages/tobias/utils/utilities.py", line 26, in <module>
    import pyBigWig
ImportError: numpy.core.multiarray failed to import
```